### PR TITLE
Solved stopwatch MFB (Premium Classic)

### DIFF
--- a/stopwatch-MFB/README.md
+++ b/stopwatch-MFB/README.md
@@ -1,0 +1,16 @@
+# Premium Classic Stopwatch & Countdown
+
+Versión refinada, fiel al estilo clásico (display LED azul + botones grandes brillantes).
+
+## Archivos
+- `index.html` – estructura y módulos (Stopwatch + Countdown)
+- `style.css` – tema Premium Clásico (LED + glossy)
+- `script.js` – precisión de tiempo y beep con WebAudio
+- `prompts.md` – historial de prompts
+
+## Uso
+Abrir `index.html` en el navegador. No requiere build ni dependencias.
+
+## Notas
+- Si el beep no se oye la primera vez, haz una interacción previa (limitaciones de autoplay).  
+- El estilo intenta emular una tipografía digital usando pesos fuertes y espaciado tabular.

--- a/stopwatch-MFB/index.html
+++ b/stopwatch-MFB/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Premium Classic Stopwatch & Countdown</title>
+    <link rel="stylesheet" href="./style.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>Stopwatch · Countdown</h1>
+    </header>
+
+    <main class="container">
+      <!-- Stopwatch -->
+      <section class="module" id="sw">
+        <h2 class="title">Stopwatch</h2>
+        <div class="display led" id="sw-display" aria-live="polite">
+          <span class="time" id="sw-main">00:00:00</span>
+          <span class="ms" id="sw-ms">000</span>
+        </div>
+        <div class="actions">
+          <button class="btn btn-green" id="sw-start">Start</button>
+          <button class="btn btn-yellow" id="sw-pause">Pause</button>
+          <button class="btn btn-red" id="sw-clear">Clear</button>
+          <button class="btn btn-gray" id="sw-lap">Lap</button>
+        </div>
+        <ol id="sw-laps" class="laps" aria-label="Lap times"></ol>
+      </section>
+
+      <!-- Countdown -->
+      <section class="module" id="cd">
+        <h2 class="title">Countdown</h2>
+        <div class="display led" id="cd-display" aria-live="polite">
+          <span class="time" id="cd-main">00:01:00</span>
+          <span class="ms" id="cd-ms">000</span>
+        </div>
+
+        <form class="inputs" id="cd-form" autocomplete="off">
+          <label>Min <input id="cd-min" type="number" min="0" value="1"></label>
+          <label>Sec <input id="cd-sec" type="number" min="0" max="59" value="0"></label>
+          <button type="button" class="btn btn-gray" id="cd-set">Set</button>
+        </form>
+
+        <div class="actions">
+          <button class="btn btn-green" id="cd-start">Start</button>
+          <button class="btn btn-yellow" id="cd-pause">Pause</button>
+          <button class="btn btn-red" id="cd-clear">Clear</button>
+          <div class="presets">
+            <button class="btn btn-gray preset" data-sec="30">30s</button>
+            <button class="btn btn-gray preset" data-sec="60">1m</button>
+            <button class="btn btn-gray preset" data-sec="300">5m</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <button id="btn-fullscreen" class="btn btn-outline">Fullscreen</button>
+    </footer>
+
+    <script src="./script.js"></script>
+  </body>
+</html>

--- a/stopwatch-MFB/prompts.md
+++ b/stopwatch-MFB/prompts.md
@@ -1,0 +1,13 @@
+# prompts.md (Premium Classic)
+
+**Chatbot:** ChatGPT (GPT-5 Thinking)  
+**Entrega:** stopwatch-CTS-premium
+
+## Prompt 1 — Estilo Premium Clásico
+> “Quiero una versión *Premium Clásico* del cronómetro + cuenta regresiva, fiel al diseño de online-stopwatch: display LED azul claro con borde grueso y esquinas muy redondeadas; números negros enormes y milisegundos como subíndice. Botones gigantes brillantes: Start (verde), Pause (amarillo), Clear (rojo), con borde oscuro y efecto ‘glossy’. Distribución centrada, responsive, accesible. Sin frameworks, solo HTML/CSS/JS.”
+
+## Prompt 2 — Precisión y sonido
+> “Stopwatch con `performance.now()` y `requestAnimationFrame` para minimizar deriva. Countdown con `Date.now()` + `endAt` para tolerar lag. Añadir beep al finalizar usando **WebAudio API** (oscillator) y parpadeo del display.”
+
+## Prompt 3 — Entregables
+> “Entrégame `index.html`, `style.css`, `script.js` y este `prompts.md`. Etiquetas en inglés (Start/Pause/Clear). Incluir presets de 30s, 1m, 5m. Botón de Fullscreen.”

--- a/stopwatch-MFB/script.js
+++ b/stopwatch-MFB/script.js
@@ -1,15 +1,15 @@
 // Premium Classic logic with accurate timing and a beep using WebAudio
-const pad = (n, s=2)=>String(n).padStart(s,'0');
+const pad = (n, s = 2) => String(n).padStart(s, "0");
 
 /* BEEP utility (WebAudio) */
-function makeBeep(){
+function makeBeep() {
   let ctx;
   return () => {
-    try{
+    try {
       ctx = ctx || new (window.AudioContext || window.webkitAudioContext)();
       const o = ctx.createOscillator();
       const g = ctx.createGain();
-      o.type = 'sine';
+      o.type = "sine";
       o.frequency.value = 880;
       g.gain.setValueAtTime(0.001, ctx.currentTime);
       g.gain.exponentialRampToValueAtTime(0.6, ctx.currentTime + 0.02);
@@ -17,72 +17,79 @@ function makeBeep(){
       o.connect(g).connect(ctx.destination);
       o.start();
       o.stop(ctx.currentTime + 0.36);
-    }catch(e){ /* ignore */ }
+    } catch (e) {
+      /* ignore */
+    }
   };
 }
 const beep = makeBeep();
 
 /* ============= STOPWATCH ============= */
-(function(){
-  const main = document.getElementById('sw-main');
-  const msEl = document.getElementById('sw-ms');
-  const startBtn = document.getElementById('sw-start');
-  const pauseBtn = document.getElementById('sw-pause');
-  const clearBtn = document.getElementById('sw-clear');
-  const lapBtn   = document.getElementById('sw-lap');
-  const laps = document.getElementById('sw-laps');
+(function () {
+  const main = document.getElementById("sw-main");
+  const msEl = document.getElementById("sw-ms");
+  const startBtn = document.getElementById("sw-start");
+  const pauseBtn = document.getElementById("sw-pause");
+  const clearBtn = document.getElementById("sw-clear");
+  const lapBtn = document.getElementById("sw-lap");
+  const laps = document.getElementById("sw-laps");
 
-  let running = false, startAt = 0, acc = 0, raf;
+  let running = false,
+    startAt = 0,
+    acc = 0,
+    raf;
 
-  const fmt = (t)=>{
+  const fmt = (t) => {
     const ms = Math.floor(t % 1000);
-    const total = Math.floor(t/1000);
-    const h = Math.floor(total/3600);
-    const m = Math.floor((total%3600)/60);
-    const s = total%60;
+    const total = Math.floor(t / 1000);
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
     return { h, m, s, ms };
   };
 
-  function render(t){
-    const {h,m,s,ms} = fmt(t);
+  function render(t) {
+    const { h, m, s, ms } = fmt(t);
     main.textContent = `${pad(h)}:${pad(m)}:${pad(s)}`;
-    msEl.textContent = pad(ms,3);
+    msEl.textContent = pad(ms, 3);
   }
 
-  function tick(){
+  function tick() {
     const now = performance.now();
     render(acc + (now - startAt));
     raf = requestAnimationFrame(tick);
   }
 
-  startBtn.addEventListener('click',()=>{
+  startBtn.addEventListener("click", () => {
     if (running) return;
     running = true;
     startAt = performance.now();
     raf = requestAnimationFrame(tick);
   });
 
-  pauseBtn.addEventListener('click',()=>{
+  pauseBtn.addEventListener("click", () => {
     if (!running) return;
     running = false;
     cancelAnimationFrame(raf);
     acc += performance.now() - startAt;
   });
 
-  clearBtn.addEventListener('click',()=>{
+  clearBtn.addEventListener("click", () => {
     running = false;
     cancelAnimationFrame(raf);
     acc = 0;
     render(0);
-    laps.innerHTML = '';
+    laps.innerHTML = "";
   });
 
-  lapBtn.addEventListener('click',()=>{
-    const t = running ? acc + (performance.now()-startAt) : acc;
-    const li = document.createElement('li');
+  lapBtn.addEventListener("click", () => {
+    const t = running ? acc + (performance.now() - startAt) : acc;
+    const li = document.createElement("li");
     const idx = laps.children.length + 1;
-    const {h,m,s,ms} = fmt(t);
-    li.innerHTML = `<span>Lap ${idx}</span><strong>${pad(h)}:${pad(m)}:${pad(s)}.${pad(ms,3)}</strong>`;
+    const { h, m, s, ms } = fmt(t);
+    li.innerHTML = `<span>Lap ${idx}</span><strong>${pad(h)}:${pad(m)}:${pad(
+      s
+    )}.${pad(ms, 3)}</strong>`;
     laps.prepend(li);
   });
 
@@ -90,39 +97,39 @@ const beep = makeBeep();
 })();
 
 /* ============= COUNTDOWN ============= */
-(function(){
-  const main = document.getElementById('cd-main');
-  const msEl = document.getElementById('cd-ms');
-  const btnStart = document.getElementById('cd-start');
-  const btnPause = document.getElementById('cd-pause');
-  const btnClear = document.getElementById('cd-clear');
-  const btnSet = document.getElementById('cd-set');
-  const minI = document.getElementById('cd-min');
-  const secI = document.getElementById('cd-sec');
-  const display = document.getElementById('cd-display');
-  const presets = document.querySelectorAll('.preset');
+(function () {
+  const main = document.getElementById("cd-main");
+  const msEl = document.getElementById("cd-ms");
+  const btnStart = document.getElementById("cd-start");
+  const btnPause = document.getElementById("cd-pause");
+  const btnClear = document.getElementById("cd-clear");
+  const btnSet = document.getElementById("cd-set");
+  const minI = document.getElementById("cd-min");
+  const secI = document.getElementById("cd-sec");
+  const display = document.getElementById("cd-display");
+  const presets = document.querySelectorAll(".preset");
 
   let duration = 60000; // ms
   let endAt = 0;
   let running = false;
   let raf;
 
-  const render = (ms)=>{
-    ms = Math.max(0, ms|0);
-    const whole = Math.floor(ms/1000);
-    const h = Math.floor(whole/3600);
-    const m = Math.floor((whole%3600)/60);
-    const s = whole%60;
+  const render = (ms) => {
+    ms = Math.max(0, ms | 0);
+    const whole = Math.floor(ms / 1000);
+    const h = Math.floor(whole / 3600);
+    const m = Math.floor((whole % 3600) / 60);
+    const s = whole % 60;
     main.textContent = `${pad(h)}:${pad(m)}:${pad(s)}`;
-    msEl.textContent = pad(ms%1000,3);
+    msEl.textContent = pad(ms % 1000, 3);
   };
 
-  function tick(){
+  function tick() {
     const left = endAt - Date.now();
-    if (left <= 0){
+    if (left <= 0) {
       running = false;
       render(0);
-      display.classList.add('blink');
+      display.classList.add("blink");
       beep();
       return;
     }
@@ -130,50 +137,71 @@ const beep = makeBeep();
     raf = requestAnimationFrame(tick);
   }
 
-  function start(){
+  function start() {
     if (running) return;
+    display.classList.remove("blink");
     endAt = Date.now() + duration;
     running = true;
     raf = requestAnimationFrame(tick);
   }
-  function pause(){
+
+  function pause() {
     if (!running) return;
     running = false;
     cancelAnimationFrame(raf);
     duration = Math.max(0, endAt - Date.now());
   }
-  function clear(){
+  function clear() {
     running = false;
     cancelAnimationFrame(raf);
-    render( (parseInt(minI.value||0)*60 + Math.min(59, parseInt(secI.value||0))) * 1000 );
-    duration = (parseInt(minI.value||0)*60 + Math.min(59, parseInt(secI.value||0))) * 1000;
+    display.classList.remove("blink");
+    render(
+      (parseInt(minI.value || 0) * 60 +
+        Math.min(59, parseInt(secI.value || 0))) *
+        1000
+    );
+    duration =
+      (parseInt(minI.value || 0) * 60 +
+        Math.min(59, parseInt(secI.value || 0))) *
+      1000;
   }
 
-  btnSet.addEventListener('click', clear);
-  btnStart.addEventListener('click', start);
-  btnPause.addEventListener('click', pause);
-  btnClear.addEventListener('click', ()=>{ duration = 0; render(0); });
+  btnSet.addEventListener("click", clear);
+  btnStart.addEventListener("click", start);
+  btnPause.addEventListener("click", pause);
 
-  presets.forEach(p=>p.addEventListener('click', ()=>{
-    const sec = parseInt(p.dataset.sec,10);
-    minI.value = Math.floor(sec/60);
-    secI.value = sec%60;
-    duration = sec*1000;
-    render(duration);
-  }));
+  btnClear.addEventListener("click", () => {
+    running = false;
+    cancelAnimationFrame(raf);
+    duration = 0;
+    endAt = 0;
+    display.classList.remove("blink");
+    render(0);
+  });
+
+  presets.forEach((p) =>
+    p.addEventListener("click", () => {
+      const sec = parseInt(p.dataset.sec, 10);
+      minI.value = Math.floor(sec / 60);
+      secI.value = sec % 60;
+      duration = sec * 1000;
+      display.classList.remove("blink");
+      render(duration);
+    })
+  );
 
   // initial render
   render(duration);
 })();
 
 /* ============= Fullscreen ============= */
-(function(){
-  const btn = document.getElementById('btn-fullscreen');
-  btn.addEventListener('click', async ()=>{
+(function () {
+  const btn = document.getElementById("btn-fullscreen");
+  btn.addEventListener("click", async () => {
     if (!document.fullscreenElement) {
-      await document.documentElement.requestFullscreen().catch(()=>{});
+      await document.documentElement.requestFullscreen().catch(() => {});
     } else {
-      await document.exitFullscreen().catch(()=>{});
+      await document.exitFullscreen().catch(() => {});
     }
   });
 })();

--- a/stopwatch-MFB/script.js
+++ b/stopwatch-MFB/script.js
@@ -1,0 +1,179 @@
+// Premium Classic logic with accurate timing and a beep using WebAudio
+const pad = (n, s=2)=>String(n).padStart(s,'0');
+
+/* BEEP utility (WebAudio) */
+function makeBeep(){
+  let ctx;
+  return () => {
+    try{
+      ctx = ctx || new (window.AudioContext || window.webkitAudioContext)();
+      const o = ctx.createOscillator();
+      const g = ctx.createGain();
+      o.type = 'sine';
+      o.frequency.value = 880;
+      g.gain.setValueAtTime(0.001, ctx.currentTime);
+      g.gain.exponentialRampToValueAtTime(0.6, ctx.currentTime + 0.02);
+      g.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.35);
+      o.connect(g).connect(ctx.destination);
+      o.start();
+      o.stop(ctx.currentTime + 0.36);
+    }catch(e){ /* ignore */ }
+  };
+}
+const beep = makeBeep();
+
+/* ============= STOPWATCH ============= */
+(function(){
+  const main = document.getElementById('sw-main');
+  const msEl = document.getElementById('sw-ms');
+  const startBtn = document.getElementById('sw-start');
+  const pauseBtn = document.getElementById('sw-pause');
+  const clearBtn = document.getElementById('sw-clear');
+  const lapBtn   = document.getElementById('sw-lap');
+  const laps = document.getElementById('sw-laps');
+
+  let running = false, startAt = 0, acc = 0, raf;
+
+  const fmt = (t)=>{
+    const ms = Math.floor(t % 1000);
+    const total = Math.floor(t/1000);
+    const h = Math.floor(total/3600);
+    const m = Math.floor((total%3600)/60);
+    const s = total%60;
+    return { h, m, s, ms };
+  };
+
+  function render(t){
+    const {h,m,s,ms} = fmt(t);
+    main.textContent = `${pad(h)}:${pad(m)}:${pad(s)}`;
+    msEl.textContent = pad(ms,3);
+  }
+
+  function tick(){
+    const now = performance.now();
+    render(acc + (now - startAt));
+    raf = requestAnimationFrame(tick);
+  }
+
+  startBtn.addEventListener('click',()=>{
+    if (running) return;
+    running = true;
+    startAt = performance.now();
+    raf = requestAnimationFrame(tick);
+  });
+
+  pauseBtn.addEventListener('click',()=>{
+    if (!running) return;
+    running = false;
+    cancelAnimationFrame(raf);
+    acc += performance.now() - startAt;
+  });
+
+  clearBtn.addEventListener('click',()=>{
+    running = false;
+    cancelAnimationFrame(raf);
+    acc = 0;
+    render(0);
+    laps.innerHTML = '';
+  });
+
+  lapBtn.addEventListener('click',()=>{
+    const t = running ? acc + (performance.now()-startAt) : acc;
+    const li = document.createElement('li');
+    const idx = laps.children.length + 1;
+    const {h,m,s,ms} = fmt(t);
+    li.innerHTML = `<span>Lap ${idx}</span><strong>${pad(h)}:${pad(m)}:${pad(s)}.${pad(ms,3)}</strong>`;
+    laps.prepend(li);
+  });
+
+  render(0);
+})();
+
+/* ============= COUNTDOWN ============= */
+(function(){
+  const main = document.getElementById('cd-main');
+  const msEl = document.getElementById('cd-ms');
+  const btnStart = document.getElementById('cd-start');
+  const btnPause = document.getElementById('cd-pause');
+  const btnClear = document.getElementById('cd-clear');
+  const btnSet = document.getElementById('cd-set');
+  const minI = document.getElementById('cd-min');
+  const secI = document.getElementById('cd-sec');
+  const display = document.getElementById('cd-display');
+  const presets = document.querySelectorAll('.preset');
+
+  let duration = 60000; // ms
+  let endAt = 0;
+  let running = false;
+  let raf;
+
+  const render = (ms)=>{
+    ms = Math.max(0, ms|0);
+    const whole = Math.floor(ms/1000);
+    const h = Math.floor(whole/3600);
+    const m = Math.floor((whole%3600)/60);
+    const s = whole%60;
+    main.textContent = `${pad(h)}:${pad(m)}:${pad(s)}`;
+    msEl.textContent = pad(ms%1000,3);
+  };
+
+  function tick(){
+    const left = endAt - Date.now();
+    if (left <= 0){
+      running = false;
+      render(0);
+      display.classList.add('blink');
+      beep();
+      return;
+    }
+    render(left);
+    raf = requestAnimationFrame(tick);
+  }
+
+  function start(){
+    if (running) return;
+    endAt = Date.now() + duration;
+    running = true;
+    raf = requestAnimationFrame(tick);
+  }
+  function pause(){
+    if (!running) return;
+    running = false;
+    cancelAnimationFrame(raf);
+    duration = Math.max(0, endAt - Date.now());
+  }
+  function clear(){
+    running = false;
+    cancelAnimationFrame(raf);
+    render( (parseInt(minI.value||0)*60 + Math.min(59, parseInt(secI.value||0))) * 1000 );
+    duration = (parseInt(minI.value||0)*60 + Math.min(59, parseInt(secI.value||0))) * 1000;
+  }
+
+  btnSet.addEventListener('click', clear);
+  btnStart.addEventListener('click', start);
+  btnPause.addEventListener('click', pause);
+  btnClear.addEventListener('click', ()=>{ duration = 0; render(0); });
+
+  presets.forEach(p=>p.addEventListener('click', ()=>{
+    const sec = parseInt(p.dataset.sec,10);
+    minI.value = Math.floor(sec/60);
+    secI.value = sec%60;
+    duration = sec*1000;
+    render(duration);
+  }));
+
+  // initial render
+  render(duration);
+})();
+
+/* ============= Fullscreen ============= */
+(function(){
+  const btn = document.getElementById('btn-fullscreen');
+  btn.addEventListener('click', async ()=>{
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen().catch(()=>{});
+    } else {
+      await document.exitFullscreen().catch(()=>{});
+    }
+  });
+})();

--- a/stopwatch-MFB/style.css
+++ b/stopwatch-MFB/style.css
@@ -1,0 +1,143 @@
+/* Premium Classic theme: LED display + glossy big buttons */
+* { box-sizing: border-box; }
+:root {
+  --bg: #f3f6ff;
+  --ink: #0b0b0b;
+  --frame: #2b2f36;
+  --led-bg: #e8edff;
+  --led-border: #2b2f36;
+  --green1: #00c13c; --green2: #00a534;
+  --red1: #ff3a2f; --red2: #e02b21;
+  --yellow1: #ffd33d; --yellow2: #e4b800;
+  --gray1: #e6e9f2; --gray2: #c7ccd9;
+}
+html, body { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, Segoe UI, Roboto, Inter, Arial, sans-serif;
+  display: flex; flex-direction: column;
+}
+
+.topbar { text-align: center; padding: .8rem 1rem; }
+.topbar h1 { margin: 0; font-size: clamp(1.1rem, 2.2vw, 1.4rem); letter-spacing: .5px; }
+
+.container {
+  width: min(1200px, 96vw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  padding: 1rem 0 2rem;
+}
+@media (min-width: 980px){
+  .container { grid-template-columns: 1fr 1fr; }
+}
+
+.module {
+  background: #fff;
+  border-radius: 28px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.12);
+  padding: 1.4rem 1.2rem 1.6rem;
+  text-align: center;
+}
+.title { font-size: clamp(1.6rem, 3vw, 2.2rem); margin: .2rem 0 1rem; }
+
+/* LED display */
+.display {
+  background: var(--led-bg);
+  border: 12px solid var(--led-border);
+  border-radius: 28px;
+  padding: .8rem 1.2rem;
+  margin: 0 auto 1rem;
+  width: min(100%, 830px);
+  position: relative;
+  box-shadow: inset 0 0 0 6px rgba(255,255,255,.8), inset 0 -10px 50px rgba(0,0,0,.08);
+}
+.display.led {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 2px;
+}
+.display .time {
+  display: inline-block;
+  font-size: clamp(2.6rem, 8vw, 7rem);
+  font-weight: 800;
+}
+.display .ms {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: .5rem;
+  font-size: clamp(1.1rem, 3vw, 2.4rem);
+  opacity: .9;
+}
+
+/* Buttons - glossy */
+.btn {
+  cursor: pointer;
+  border: 6px solid #333a;
+  color: #111;
+  border-radius: 26px;
+  padding: 0.8rem 1.6rem;
+  min-width: 150px;
+  font-size: clamp(1rem, 2.8vw, 2rem);
+  font-weight: 700;
+  box-shadow: inset 0 8px 0 rgba(255,255,255,.45), 0 10px 20px rgba(0,0,0,.18);
+  transition: transform .06s ease, filter .15s ease;
+  user-select: none;
+}
+.btn:active { transform: translateY(2px) scale(.99); }
+
+.btn-green { background: linear-gradient(#39f77a, #01b94a); }
+.btn-red   { background: linear-gradient(var(--red1), var(--red2)); }
+.btn-yellow{ background: linear-gradient(var(--yellow1), var(--yellow2)); }
+.btn-gray  { background: linear-gradient(var(--gray1), var(--gray2)); }
+
+.btn-outline {
+  background: transparent;
+  border: 3px dashed #667;
+  box-shadow: none;
+  font-size: 1rem;
+  min-width: auto;
+  padding: .6rem 1rem;
+}
+
+.actions {
+  display: flex; flex-wrap: wrap; gap: 1rem;
+  justify-content: center; align-items: center;
+  margin: 1rem 0 .5rem;
+}
+
+.inputs {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: .8rem 1rem;
+  justify-content: center;
+  align-items: end;
+  margin: 0 auto .5rem;
+}
+.inputs label { font-weight: 600; font-size: 1rem; display: grid; gap: .4rem; }
+.inputs input {
+  padding: .6rem .8rem; border-radius: 12px; border: 2px solid #9aa7c0;
+  font-size: 1.1rem; width: 90px; text-align: center;
+}
+
+.presets { display: flex; gap: .6rem; }
+
+/* Laps list */
+.laps {
+  list-style: none; padding: .2rem; margin: .6rem auto 0;
+  max-height: 210px; overflow: auto; width: min(95%, 720px);
+  border-top: 2px dashed #c6cee2;
+}
+.laps li {
+  display: flex; justify-content: space-between; padding: .35rem .4rem;
+  font-variant-numeric: tabular-nums;
+}
+.laps li:nth-child(odd){ background: #f6f8ff; }
+
+/* Effects */
+.blink { animation: blink 200ms step-start 5; }
+@keyframes blink { 50% { opacity: 0; } }
+
+.footer { display:flex; gap:.8rem; justify-content:center; padding: 1rem; color:#456; }


### PR DESCRIPTION
# prompts.md (Premium Classic)

**Chatbot:** ChatGPT (GPT-5 Thinking)  
**Entrega:** stopwatch-HMF (Premium Classic)

## Prompt 1 — Estilo Premium Clásico
> “Quiero una versión *Premium Clásico* del cronómetro + cuenta regresiva, fiel al diseño de online-stopwatch: display LED azul claro con borde grueso y esquinas muy redondeadas; números negros enormes y milisegundos como subíndice. Botones gigantes brillantes: Start (verde), Pause (amarillo), Clear (rojo), con borde oscuro y efecto ‘glossy’. Distribución centrada, responsive, accesible. Sin frameworks, solo HTML/CSS/JS.”

## Prompt 2 — Precisión y sonido
> “Stopwatch con `performance.now()` y `requestAnimationFrame` para minimizar deriva. Countdown con `Date.now()` + `endAt` para tolerar lag. Añadir beep al finalizar usando **WebAudio API** (oscillator) y parpadeo del display.”

## Prompt 3 — Entregables
> “Entrégame `index.html`, `style.css`, `script.js` y este `prompts.md`. Etiquetas en inglés (Start/Pause/Clear). Incluir presets de 30s, 1m, 5m. Botón de Fullscreen.”


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Premium Classic Stopwatch & Countdown: start/pause/clear, laps, editable time inputs, presets (30s, 1m, 5m), finish beep, visual blink and fullscreen toggle; ARIA live updates and responsive layout.

- Style
  - Blue LED display theme, glossy color‑coded buttons, card modules, refined typography, animations and responsive sizing.

- Documentation
  - Added README with usage/notes and prompts document describing design and deliverables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->